### PR TITLE
Added option to fully mask profane words.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ This plugin is built on the assumption that profanity filters need to be impleme
 
 ## Configuration
 
-This plugin supports 2 basic options that can be configured:
+This plugin supports 3 basic options that can be configured:
 
 	{
 		mask: '$', //default '*'
+		fullyMasked: true, // default false
 		blacklist: ['foul', 'slang'] //default []
 	}
 
 `mask` (optional) is used to filter foul words with a character of your choice; default is asterisk (*)
+
+`fullyMasked` (optional) is used to replace all letters in profance words with the mask character, instead of just the inner letters
 
 `blacklist` (optional) is used to define words that you wish to filter in addition to the default dictionary; default is an empty array;
 
@@ -100,6 +103,13 @@ To count the rating, simply call the rating function as below:
 	var computedRating = rating(resStub.profaneWordsCount);
 	console.log("Rating of profanity is ", computedRating);
 
+**Fully Masking Profane Words**
+
+By default, the middleware will leave the first and last letter of a profane word unmasked. To mask the full word, including first and last letters, add the `fullyMasked` option to the filter object and set it to `true`, like below:
+
+    ...
+    filter('enterBadWordHere', {fullyMasked: true}, resStub);
+    ...
 
 ## Tests
 
@@ -111,6 +121,7 @@ To count the rating, simply call the rating function as below:
   - Check for custom words and custom mask 
   - Check for count of profane words
   - Check rating of profane words
+  - Check for fully masking words as alternate option
 
 ## Contributing
 
@@ -119,6 +130,7 @@ Add unit tests for any new or changed functionality. Lint and test your code.
 
 ## Release History
 
+* 0.3.0 Added backwards-compatible option to fully mask profane words
 * 0.2.1 Profane words rating calculator function added
 * 0.2.0 Profane word counts added
 * 0.1.4 GHOST Enhancement

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = new (function() {
 	var words = require('./words.json');
 	var defaultConfig = {
 		mask: '*',
+		fullyMasked: false,
 		blacklist: []
 	}
 	var wordFilter = function(str, res) {
@@ -15,7 +16,9 @@ module.exports = new (function() {
 			res.profaneWordsCount++;
 			var word = str;
 			var wordLen = word.length;
-			str = word.substr(0,1) + Array(wordLen-1).join(defaultConfig.mask) + word.substr(wordLen-1,1);
+			str = defaultConfig.fullyMasked ? 
+				Array(wordLen+1).join(defaultConfig.mask) :
+				word.substr(0,1) + Array(wordLen-1).join(defaultConfig.mask) + word.substr(wordLen-1,1);
 		} else {
 			str = originalStr;
 		}
@@ -64,6 +67,7 @@ module.exports = new (function() {
 			res.profaneWordsCount = 0;
 		if (options != undefined) {
 			defaultConfig.mask = (options.mask != undefined ? options.mask : defaultConfig.mask);
+			defaultConfig.fullyMasked = (options.fullyMasked != undefined ? options.fullyMasked : defaultConfig.fullyMasked);
 			defaultConfig.blacklist = (options.blacklist != undefined ? options.blacklist : defaultConfig.blacklist);
 		}
 
@@ -82,6 +86,7 @@ module.exports = new (function() {
 	var setOptions = function(options) {
 		if (options != undefined) {
 			defaultConfig.mask = (options.mask != undefined ? options.mask : defaultConfig.mask);
+			defaultConfig.fullyMasked = (options.fullyMasked != undefined ? options.fullyMasked : defaultConfig.fullyMasked);
 			defaultConfig.blacklist = (options.blacklist != undefined ? options.blacklist : defaultConfig.blacklist);
 		}
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,12 @@ describe('#filter', function() {
 		resStub.profaneWordsCount.should.equal(3);
 		rating(resStub.profaneWordsCount).should.equal(6); //3 bad words meaning it is 6% foul
 	});
+
+	var str7 = 'Fucking shit happens many a times to him because he is such an ass';
+	var filteredStr7 = '******* **** happens many a times to him because he is such an ***';
+	it('Check for fully masking words as alternate option', function() {
+		filter(str7, {fullyMasked: true}).should.equal(filteredStr7);
+	});
 	/*
 	it('converts shit shit to s*** s***', function() {
 		filter(' shit shit ').should.equal(' s*** s*** ');


### PR DESCRIPTION
This is a pretty simple change, just allows the full word to be masked instead of just the first and last characters. Modified the README to include documentation changes and proposed bumping the version to 0.3.0 since it is a backwards compatible change. I'll leave that up to you, however, and bumping the actual package.json version. 
